### PR TITLE
try to remove semicolon in bottom of body

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,6 +18,7 @@ const font = Lato({
 });
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  // prettier-ignore
   return (
     <html lang="en">
       <body className={font.className}>
@@ -31,5 +32,5 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         </div>
       </body>
     </html>
-  );
+  )
 }


### PR DESCRIPTION
Semicolon was showing up at bottom of page after deployment. Remove the semicolon in the homepage return