### PR TITLE
switch from GA to GTM and add initial Cookie Consent modal

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -81,6 +81,7 @@ jobs:
           NEXT_PUBLIC_EMAILJS_SERVICE_ID: ${{ secrets.NEXT_PUBLIC_EMAILJS_SERVICE_ID }}
           NEXT_PUBLIC_EMAILJS_TEMPLATE_ID: ${{ secrets.NEXT_PUBLIC_EMAILJS_TEMPLATE_ID }}
           NEXT_PUBLIC_GA_ID: ${{ secrets.NEXT_PUBLIC_GA_ID }}
+          NEXT_PUBLIC_GTM_ID: ${{ secrets.NEXT_PUBLIC_GTM_ID }}
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env*.local
 
 # vercel

--- a/app/components/CookieConsent.tsx
+++ b/app/components/CookieConsent.tsx
@@ -1,0 +1,58 @@
+'use client';
+import { setCookie, hasCookie } from 'cookies-next';
+import { useState, useEffect } from 'react';
+
+export const CookieConsent = () => {
+  const [showConsent, setShowConsent] = useState(false);
+
+  useEffect(() => {
+    // If no consent cookie is present, show the consent popup
+    if (!hasCookie('consent')) {
+      setShowConsent(true);
+    }
+  }, []);
+
+  const acceptConsent = () => {
+    // When user accepts consent, hide the popup and set a consent cookie
+    setShowConsent(false);
+    setCookie('consent', 'true');
+
+    // Trigger GTM script load
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new Event('updateGTMConsent'));
+    }
+  };
+  const declineConsent = () => {
+    // When user declines the consent, simply hide the popup
+    setShowConsent(false);
+  };
+
+  if (!showConsent) {
+    return null;
+  }
+
+  return (
+    <div className="ml-0 fixed bottom-0 left-1/2 w-full sm:w-3/4 md:w-1/2 lg:w-1/3 xl:w-1/3 max-w-2xl min-w-xs p-8 m-4 bg-neutral-500 text-white flex flex-col items-center justify-center transform -translate-x-1/2 rounded-lg">
+      <div>
+        <p>
+          We use some <strong>standard analytics packages</strong> to understand general user behaviour, so we can
+          figure out how to improve our content. This involves some cookies. Are you OK with this?
+        </p>
+      </div>
+      <div className="flex mt-4">
+        <button
+          onClick={acceptConsent}
+          className="bg-white text-neutral-700 px-4 py-2 rounded mr-2 hover:bg-neutral-200"
+        >
+          Accept
+        </button>
+        <button
+          onClick={declineConsent}
+          className="bg-white text-neutral-700 px-4 py-2 rounded mr-2 hover:bg-neutral-200 hover:text-neutral-900"
+        >
+          Decline
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,8 @@ import Footer from './components/footer/Footer';
 import DemoModal from './components/modals/DemoModal';
 import ImageModal from './components/modals/ImageModal';
 import ToasterProvider from './providers/ToasterProvider';
-import { GoogleAnalytics } from '@next/third-parties/google';
+import { GoogleTagManager } from '@next/third-parties/google';
+import { CookieConsent } from './components/CookieConsent';
 
 export const metadata = {
   title: 'cambioml',
@@ -31,7 +32,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <Footer />
         </div>
       </body>
-      <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID || ''} />
+      <GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GTM_ID || ''} />
+      <CookieConsent />
     </html>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react-syntax-highlighter": "^15.5.11",
         "autoprefixer": "10.4.16",
         "axios": "^1.6.7",
+        "cookies-next": "^4.1.1",
         "eslint-config-next": "14.0.4",
         "next": "^14.1.0",
         "postcss": "8.4.33",
@@ -31,7 +32,6 @@
         "tailwindcss": "3.4.1",
         "typescript": "5.3.3",
         "uuid": "^9.0.1",
-        "yarn": "^1.22.21",
         "zustand": "^4.4.7"
       },
       "devDependencies": {
@@ -555,6 +555,11 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
     },
     "node_modules/@types/hast": {
       "version": "2.3.9",
@@ -1428,6 +1433,29 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookies-next": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/cookies-next/-/cookies-next-4.1.1.tgz",
+      "integrity": "sha512-20QaN0iQSz87Os0BhNg9M71eM++gylT3N5szTlhq2rK6QvXn1FYGPB4eAgU4qFTunbQKhD35zfQ95ZWgzUy3Cg==",
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "@types/node": "^16.10.2",
+        "cookie": "^0.6.0"
+      }
+    },
+    "node_modules/cookies-next/node_modules/@types/node": {
+      "version": "16.18.79",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.79.tgz",
+      "integrity": "sha512-Qd7jdLR5zmnIyMhfDrfPqN5tUCvreVpP3Qrf2oSM+F7SNzlb/MwHISGUkdFHtevfkPJ3iAGyeQI/jsbh9EStgQ=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -5293,19 +5321,6 @@
       "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/yarn": {
-      "version": "1.22.21",
-      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.21.tgz",
-      "integrity": "sha512-ynXaJsADJ9JiZ84zU25XkPGOvVMmZ5b7tmTSpKURYwgELdjucAOydqIOrOfTxVYcNXe91xvLZwcRh68SR3liCg==",
-      "hasInstallScript": true,
-      "bin": {
-        "yarn": "bin/yarn.js",
-        "yarnpkg": "bin/yarn.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/react-syntax-highlighter": "^15.5.11",
     "autoprefixer": "10.4.16",
     "axios": "^1.6.7",
+    "cookies-next": "^4.1.1",
     "eslint-config-next": "14.0.4",
     "next": "^14.1.0",
     "postcss": "8.4.33",


### PR DESCRIPTION
- Switch from Google Analytics to Google Tag Manager, add to root layout
- Create initial CookieConsent component and add to root layout