### PR TITLE
fix container overflow

### DIFF
--- a/app/components/playground/ActionContainer.tsx
+++ b/app/components/playground/ActionContainer.tsx
@@ -18,7 +18,7 @@ const ActionContainer = () => {
   }, [selectedFileIndex, files]);
 
   return (
-    <div className="w-full h-full min-h-[600px] grid grid-rows-[50px_1fr]">
+    <div className="w-full h-full min-h-[600px] grid grid-rows-[50px_1fr] overflow-hidden">
       <div className={`w-full grid grid-cols-2`}>
         {Object.values(PlaygroundTabs).map((tab) => (
           <PlaygroundTab key={tab} label={tab} />
@@ -26,14 +26,14 @@ const ActionContainer = () => {
       </div>
       {loggedIn ? (
         selectedFileIndex === null ? (
-          <div className="flex flex-col items-center justify-center h-full overflow-auto gap-4">
+          <div className="flex flex-col items-center justify-center h-full overflow-hidden gap-4">
             <div className="text-xl font-semibold text-neutral-500">Please upload a file.</div>
             <div className="w-[300px]">
               <UploadButton small />
             </div>
           </div>
         ) : (
-          <div className="h-full border border-solid border-2 border-t-0 border-neutral-200 rounded-b-xl p-4 pt-0">
+          <div className="h-full border border-solid border-2 border-t-0 border-neutral-200 rounded-b-xl p-4 pt-0 overflow-hidden">
             {(selectedFile?.activeTab === PlaygroundTabs.PLAIN_TEXT || selectedFileIndex === null) && (
               <ExtractContainer />
             )}

--- a/app/components/playground/PlaygroundContainer.tsx
+++ b/app/components/playground/PlaygroundContainer.tsx
@@ -9,14 +9,14 @@ import usePlaygroundStore from '@/app/hooks/usePlaygroundStore';
 
 const PlaygroundContainer = () => {
   const { fileCollapsed } = usePlaygroundStore();
-  const playgroundWrapperStyles = `border-solid border-[1px] border-neutral-gray }`;
+  const playgroundWrapperStyles = `border-solid border-[1px] border-neutral-gray`;
 
   return (
     <>
       <PreviewModal />
       <CompareModal />
       <PlaygroundInfoBar />
-      <div className="w-full min-w-[600px] max-w-[2520px] flex flex-col gap-0 h-fit lg:h-fit">
+      <div className="w-full min-w-[600px] max-w-[2520px] flex flex-col gap-0 h-fit lg:h-fit overflow-hidden">
         <div
           className={`
             w-full
@@ -27,13 +27,16 @@ const PlaygroundContainer = () => {
             grid-cols-1
             transition-all
             duration-300
+            overflow-hidden
             ${fileCollapsed ? 'lg:grid-cols-[100px_1fr]' : 'lg:grid-cols-[325px_1fr]'}
           `}
         >
-          <div className={`${playgroundWrapperStyles}  bg-neutral-100 ${fileCollapsed ? 'p-2' : 'p-6 pl-10'} pr-0 `}>
+          <div
+            className={`${playgroundWrapperStyles} bg-neutral-100 ${fileCollapsed ? 'p-2' : 'p-6 pl-10'} pr-0 overflow-hidden`}
+          >
             <FilesContainer />
           </div>
-          <div className={`${playgroundWrapperStyles} border-l-[1px] border-b-[1px] p-6 pr-10`}>
+          <div className={`${playgroundWrapperStyles} border-l-[1px] border-b-[1px] p-6 pr-10 overflow-hidden`}>
             <ActionContainer />
           </div>
         </div>

--- a/app/components/playground/ResultContainer.tsx
+++ b/app/components/playground/ResultContainer.tsx
@@ -109,7 +109,7 @@ const ResultContent = ({ extractResult }: ResultContentProps) => {
       </div>
       <div
         ref={containerRef}
-        className="overflow-auto relative w-full h-full rounded-xl border border-1 border-solid px-10"
+        className="overflow-auto relative w-full h-full rounded-xl border border-1 border-solid px-10 max-w-full"
       >
         {extractResult.map((content, index) => (
           <div key={index} className="p-4 w-full border-b-2" style={{ minHeight: '100%' }} id="result-container">


### PR DESCRIPTION
## Description
Current our sandbox container has text overflow issue...
<img width="438" alt="image" src="https://github.com/user-attachments/assets/2960af28-8de5-48a0-a3be-158bb1af57ac">


## Related Issue
N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## How Has This Been Tested?
I tested on the previously overflowed file and the problems are gone.

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any additional notes or context about the PR here --> 
