### PR TITLE
feat: Support RTL in PDF extraction

### DIFF
--- a/app/components/playground/ResultContainer.tsx
+++ b/app/components/playground/ResultContainer.tsx
@@ -115,17 +115,39 @@ const ResultContent = ({ extractResult }: ResultContentProps) => {
           <div key={index} className="p-4 w-full border-b-2" style={{ minHeight: '100%' }} id="result-container">
             {hasHtmlTags(content) ? (
               <div
+                dir="auto"
                 dangerouslySetInnerHTML={{
-                  // Convert triple newlines (\n\n\n) to double HTML line breaks (<br/><br/>)
-                  // This preserves the spacing/formatting in the rendered HTML output
-                  // Without this, all newlines would be collapsed into a single space
                   __html: content.replace(/\n\n\n/g, '<br/><br/>'),
                 }}
               />
             ) : (
-              <Markdown className="markdown" remarkPlugins={[remarkGfm]}>
-                {content}
-              </Markdown>
+              <div dir="auto">
+                <Markdown
+                  className="markdown"
+                  remarkPlugins={[remarkGfm]}
+                  components={{
+                    p: ({ node, ...props }) => <p dir="auto" {...props} />,
+                    h1: ({ node, ...props }) => <h1 dir="auto" {...props} />,
+                    h2: ({ node, ...props }) => <h2 dir="auto" {...props} />,
+                    h3: ({ node, ...props }) => <h3 dir="auto" {...props} />,
+                    h4: ({ node, ...props }) => <h4 dir="auto" {...props} />,
+                    h5: ({ node, ...props }) => <h5 dir="auto" {...props} />,
+                    h6: ({ node, ...props }) => <h6 dir="auto" {...props} />,
+                    ul: ({ node, ...props }) => <ul dir="auto" {...props} />,
+                    ol: ({ node, ...props }) => <ol dir="auto" {...props} />,
+                    li: ({ node, ...props }) => <li dir="auto" {...props} />,
+                    tr: ({ node, ...props }) => <tr dir="auto" {...props} />,
+                    td: ({ node, ...props }) => <td dir="auto" {...props} />,
+                    th: ({ node, ...props }) => <th dir="auto" {...props} />,
+                    pre: ({ node, ...props }) => <pre dir="auto" {...props} />,
+                    code: ({ node, ...props }) => <code dir="auto" {...props} />,
+                    table: ({ node, ...props }) => <table dir="auto" {...props} />,
+                    blockquote: ({ node, ...props }) => <blockquote dir="auto" {...props} />,
+                  }}
+                >
+                  {content}
+                </Markdown>
+              </div>
             )}
           </div>
         ))}

--- a/app/components/playground/ResultContainer.tsx
+++ b/app/components/playground/ResultContainer.tsx
@@ -121,33 +121,32 @@ const ResultContent = ({ extractResult }: ResultContentProps) => {
                 }}
               />
             ) : (
-              <div dir="auto">
-                <Markdown
-                  className="markdown"
-                  remarkPlugins={[remarkGfm]}
-                  components={{
-                    p: ({ node, ...props }) => <p dir="auto" {...props} />,
-                    h1: ({ node, ...props }) => <h1 dir="auto" {...props} />,
-                    h2: ({ node, ...props }) => <h2 dir="auto" {...props} />,
-                    h3: ({ node, ...props }) => <h3 dir="auto" {...props} />,
-                    h4: ({ node, ...props }) => <h4 dir="auto" {...props} />,
-                    h5: ({ node, ...props }) => <h5 dir="auto" {...props} />,
-                    h6: ({ node, ...props }) => <h6 dir="auto" {...props} />,
-                    ul: ({ node, ...props }) => <ul dir="auto" {...props} />,
-                    ol: ({ node, ...props }) => <ol dir="auto" {...props} />,
-                    li: ({ node, ...props }) => <li dir="auto" {...props} />,
-                    tr: ({ node, ...props }) => <tr dir="auto" {...props} />,
-                    td: ({ node, ...props }) => <td dir="auto" {...props} />,
-                    th: ({ node, ...props }) => <th dir="auto" {...props} />,
-                    pre: ({ node, ...props }) => <pre dir="auto" {...props} />,
-                    code: ({ node, ...props }) => <code dir="auto" {...props} />,
-                    table: ({ node, ...props }) => <table dir="auto" {...props} />,
-                    blockquote: ({ node, ...props }) => <blockquote dir="auto" {...props} />,
-                  }}
-                >
-                  {content}
-                </Markdown>
-              </div>
+              // This complex way ensures only arabic text is RTL for every different line
+              <Markdown
+                className="markdown"
+                remarkPlugins={[remarkGfm]}
+                components={{
+                  p: ({ ...props }) => <p dir="auto" {...props} />,
+                  h1: ({ ...props }) => <h1 dir="auto" {...props} />,
+                  h2: ({ ...props }) => <h2 dir="auto" {...props} />,
+                  h3: ({ ...props }) => <h3 dir="auto" {...props} />,
+                  h4: ({ ...props }) => <h4 dir="auto" {...props} />,
+                  h5: ({ ...props }) => <h5 dir="auto" {...props} />,
+                  h6: ({ ...props }) => <h6 dir="auto" {...props} />,
+                  ul: ({ ...props }) => <ul dir="auto" {...props} />,
+                  ol: ({ ...props }) => <ol dir="auto" {...props} />,
+                  li: ({ ...props }) => <li dir="auto" {...props} />,
+                  tr: ({ ...props }) => <tr dir="auto" {...props} />,
+                  td: ({ ...props }) => <td dir="auto" {...props} />,
+                  th: ({ ...props }) => <th dir="auto" {...props} />,
+                  pre: ({ ...props }) => <pre dir="auto" {...props} />,
+                  code: ({ ...props }) => <code dir="auto" {...props} />,
+                  table: ({ ...props }) => <table dir="auto" {...props} />,
+                  blockquote: ({ ...props }) => <blockquote dir="auto" {...props} />,
+                }}
+              >
+                {content}
+              </Markdown>
             )}
           </div>
         ))}

--- a/app/components/playground/ResultContainer.tsx
+++ b/app/components/playground/ResultContainer.tsx
@@ -7,12 +7,32 @@ import useResultZoomModal from '@/app/hooks/useResultZoomModal';
 import { CaretLeft, CaretRight, Copy, Files, FrameCorners } from '@phosphor-icons/react';
 import { useEffect, useRef, useState } from 'react';
 import toast from 'react-hot-toast';
-import Markdown from 'react-markdown';
+import Markdown, { Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
 interface ResultContentProps {
   extractResult: QueryResult;
 }
+
+const markdownComponents: Components = {
+  p: ({ ...props }) => <p dir="auto" {...props} />,
+  h1: ({ ...props }) => <h1 dir="auto" {...props} />,
+  h2: ({ ...props }) => <h2 dir="auto" {...props} />,
+  h3: ({ ...props }) => <h3 dir="auto" {...props} />,
+  h4: ({ ...props }) => <h4 dir="auto" {...props} />,
+  h5: ({ ...props }) => <h5 dir="auto" {...props} />,
+  h6: ({ ...props }) => <h6 dir="auto" {...props} />,
+  ul: ({ ...props }) => <ul dir="auto" {...props} />,
+  ol: ({ ...props }) => <ol dir="auto" {...props} />,
+  li: ({ ...props }) => <li dir="auto" {...props} />,
+  tr: ({ ...props }) => <tr dir="auto" {...props} />,
+  td: ({ ...props }) => <td dir="auto" {...props} />,
+  th: ({ ...props }) => <th dir="auto" {...props} />,
+  pre: ({ ...props }) => <pre dir="auto" {...props} />,
+  code: ({ ...props }) => <code dir="auto" {...props} />,
+  table: ({ ...props }) => <table dir="auto" {...props} />,
+  blockquote: ({ ...props }) => <blockquote dir="auto" {...props} />,
+};
 
 const ResultContent = ({ extractResult }: ResultContentProps) => {
   const resultZoomModal = useResultZoomModal();
@@ -117,34 +137,15 @@ const ResultContent = ({ extractResult }: ResultContentProps) => {
               <div
                 dir="auto"
                 dangerouslySetInnerHTML={{
+                  // Convert triple newlines (\n\n\n) to double HTML line breaks (<br/><br/>)
+                  // This preserves the spacing/formatting in the rendered HTML output
+                  // Without this, all newlines would be collapsed into a single space
                   __html: content.replace(/\n\n\n/g, '<br/><br/>'),
                 }}
               />
             ) : (
               // This complex way ensures only arabic text is RTL for every different line
-              <Markdown
-                className="markdown"
-                remarkPlugins={[remarkGfm]}
-                components={{
-                  p: ({ ...props }) => <p dir="auto" {...props} />,
-                  h1: ({ ...props }) => <h1 dir="auto" {...props} />,
-                  h2: ({ ...props }) => <h2 dir="auto" {...props} />,
-                  h3: ({ ...props }) => <h3 dir="auto" {...props} />,
-                  h4: ({ ...props }) => <h4 dir="auto" {...props} />,
-                  h5: ({ ...props }) => <h5 dir="auto" {...props} />,
-                  h6: ({ ...props }) => <h6 dir="auto" {...props} />,
-                  ul: ({ ...props }) => <ul dir="auto" {...props} />,
-                  ol: ({ ...props }) => <ol dir="auto" {...props} />,
-                  li: ({ ...props }) => <li dir="auto" {...props} />,
-                  tr: ({ ...props }) => <tr dir="auto" {...props} />,
-                  td: ({ ...props }) => <td dir="auto" {...props} />,
-                  th: ({ ...props }) => <th dir="auto" {...props} />,
-                  pre: ({ ...props }) => <pre dir="auto" {...props} />,
-                  code: ({ ...props }) => <code dir="auto" {...props} />,
-                  table: ({ ...props }) => <table dir="auto" {...props} />,
-                  blockquote: ({ ...props }) => <blockquote dir="auto" {...props} />,
-                }}
-              >
+              <Markdown className="markdown" remarkPlugins={[remarkGfm]} components={markdownComponents}>
                 {content}
               </Markdown>
             )}
@@ -205,7 +206,11 @@ const ResultContainer = ({ extractResult }: ResultContainerProps) => {
             }}
           />
         ) : (
-          <Markdown className="markdown p-4 whitespace-pre-wrap" remarkPlugins={[remarkGfm]}>
+          <Markdown
+            className="markdown p-4 whitespace-pre-wrap"
+            remarkPlugins={[remarkGfm]}
+            components={markdownComponents}
+          >
             {extractResult
               .map((content, index) => {
                 return `${content}\n\n**Page ${index + 1}**\n\n---\n\n`;


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes introduced by this PR -->

HTML support to use `dir="auto"` to enable RTL. However, I'm overriding the `react-markdown` components because this approach ensures that when extracting a document with both Arabic and English, the English lines are still LTR instead of they all get rendered as RTL.

## Related Issue

<!-- Link to the related issue (if applicable) using #issue_number -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## How Has This Been Tested?

Use this file to test this feature with AP-Pro mode: [arabic.pdf](https://github.com/user-attachments/files/18291538/arabic.pdf)

Depends on our scenario, feel free to find some more complicated file.

<!-- Describe the tests you ran to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

![image](https://github.com/user-attachments/assets/4ee4ac49-6e78-4269-9420-804d321103b6)

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

<!-- Add any additional notes or context about the PR here -->
