### PR TITLE
chore: disable anyparser pro model

### DIFF
--- a/app/components/playground/ModelToggleDropdown.tsx
+++ b/app/components/playground/ModelToggleDropdown.tsx
@@ -33,7 +33,7 @@ const ModelToggleDropdown = () => {
     }
   };
 
-  const disabledTypes: ModelType[] = [ModelType.ULTRA];
+  const disabledTypes: ModelType[] = [ModelType.PRO, ModelType.ULTRA];
 
   return (
     <div className="relative inline-block text-left">


### PR DESCRIPTION
## Description

Disabled the AnyParser Pro model in the playground by adding `ModelType.PRO` to the `disabledTypes` array in the ModelToggleDropdown component. This prevents users from selecting the Pro model option in the dropdown.

## Related Issue

<!-- No related issue -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement

## How Has This Been Tested?

The change has been verified by checking that the `disabledTypes` array now includes both `ModelType.PRO` and `ModelType.ULTRA`, which will prevent the Pro model from appearing in the dropdown options.

## Screenshots (if applicable)

<!-- No screenshots needed for this change -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes

This is a simple configuration change to temporarily disable the Pro model option from the model selection dropdown in the playground interface.